### PR TITLE
[infra] acm,cloudfront,s3,route53 설정

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,6 +12,11 @@ provider "aws" {
   region = "ap-northeast-2"
 }
 
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
 # VPC
 module "vpc" {
   source = "./modules/network/vpc"
@@ -99,6 +104,130 @@ module "route_tables" {
       name       = "${var.service_name}-PrivateSubnetRouteTable"
       subnet_ids = module.subnets.private_subnet_ids
       routes     = []
+    }
+  ]
+}
+
+
+
+# Website Hosting
+locals {
+  domain_name = "savemypodo.shop"
+  bucket_name = "savemypodo-website"
+}
+
+# S3 Bucket for Website
+module "website_bucket" {
+  source = "./modules/s3"
+
+  bucket_name               = local.bucket_name
+  enable_website            = true
+  block_public_acls         = false
+  block_public_policy       = false
+  ignore_public_acls        = false
+  restrict_public_buckets   = false
+  
+  bucket_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "PublicReadGetObject"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource  = "arn:aws:s3:::${local.bucket_name}/*"
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "Website Hosting"
+    Environment = var.environment
+  }
+}
+
+# Route53 Hosted Zone
+module "dns" {
+  source = "./modules/route53"
+
+  domain_name = local.domain_name
+  create_zone = true
+
+  tags = {
+    Name        = "Website DNS"
+    Environment = var.environment
+  }
+}
+
+# ACM Certificate
+module "certificate" {
+  source = "./modules/acm"
+
+  domain_name               = local.domain_name
+  subject_alternative_names = ["www.${local.domain_name}"]
+  zone_id                   = module.dns.zone_id
+
+  tags = {
+    Name        = "Website Certificate"
+    Environment = var.environment
+  }
+
+  providers = {
+    aws = aws.us_east_1
+  }
+}
+
+# CloudFront Distribution
+module "cdn" {
+  source = "./modules/cloudfront"
+
+  origin_domain_name = module.website_bucket.website_endpoint
+  origin_id          = "S3-${local.bucket_name}"
+  aliases            = [local.domain_name, "www.${local.domain_name}"]
+  certificate_arn    = module.certificate.certificate_arn
+
+  custom_error_responses = [
+    {
+      error_code         = 404
+      response_code      = 200
+      response_page_path = "/index.html"
+    }
+  ]
+
+  tags = {
+    Name        = "Website CDN"
+    Environment = var.environment
+  }
+
+  depends_on = [module.certificate]
+}
+
+# DNS Records
+module "dns_records" {
+  source = "./modules/route53"
+
+  domain_name = local.domain_name
+  create_zone = false
+  zone_id     = module.dns.zone_id
+
+  records = [
+    {
+      name = ""
+      type = "A"
+      alias = {
+        name                   = module.cdn.distribution_domain_name
+        zone_id                = module.cdn.distribution_hosted_zone_id
+        evaluate_target_health = false
+      }
+    },
+    {
+      name = "www"
+      type = "A"
+      alias = {
+        name                   = module.cdn.distribution_domain_name
+        zone_id                = module.cdn.distribution_hosted_zone_id
+        evaluate_target_health = false
+      }
     }
   ]
 }

--- a/terraform/modules/acm/main.tf
+++ b/terraform/modules/acm/main.tf
@@ -1,0 +1,34 @@
+resource "aws_acm_certificate" "this" {
+  domain_name               = var.domain_name
+  subject_alternative_names = var.subject_alternative_names
+  validation_method         = var.validation_method
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_route53_record" "validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    } if var.zone_id != ""
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = var.zone_id
+}
+
+resource "aws_acm_certificate_validation" "this" {
+  count           = var.zone_id != "" ? 1 : 0
+  certificate_arn = aws_acm_certificate.this.arn
+  validation_record_fqdns = [for record in aws_route53_record.validation : record.fqdn]
+}

--- a/terraform/modules/acm/main.tf
+++ b/terraform/modules/acm/main.tf
@@ -1,4 +1,5 @@
 resource "aws_acm_certificate" "this" {
+  
   domain_name               = var.domain_name
   subject_alternative_names = var.subject_alternative_names
   validation_method         = var.validation_method
@@ -16,7 +17,7 @@ resource "aws_route53_record" "validation" {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
-    } if var.zone_id != ""
+    }
   }
 
   allow_overwrite = true
@@ -28,7 +29,7 @@ resource "aws_route53_record" "validation" {
 }
 
 resource "aws_acm_certificate_validation" "this" {
-  count           = var.zone_id != "" ? 1 : 0
   certificate_arn = aws_acm_certificate.this.arn
   validation_record_fqdns = [for record in aws_route53_record.validation : record.fqdn]
+  depends_on = [ aws_route53_record.validation ]
 }

--- a/terraform/modules/acm/outputs.tf
+++ b/terraform/modules/acm/outputs.tf
@@ -1,0 +1,14 @@
+output "certificate_arn" {
+  description = "ARN of the ACM certificate"
+  value       = aws_acm_certificate.this.arn
+}
+
+output "certificate_domain_name" {
+  description = "Domain name of the certificate"
+  value       = aws_acm_certificate.this.domain_name
+}
+
+output "certificate_status" {
+  description = "Status of the certificate"
+  value       = aws_acm_certificate.this.status
+}

--- a/terraform/modules/acm/variables.tf
+++ b/terraform/modules/acm/variables.tf
@@ -1,0 +1,28 @@
+variable "domain_name" {
+  description = "Domain name for the certificate"
+  type        = string
+}
+
+variable "subject_alternative_names" {
+  description = "Subject alternative names for the certificate"
+  type        = list(string)
+  default     = []
+}
+
+variable "validation_method" {
+  description = "Validation method for the certificate"
+  type        = string
+  default     = "DNS"
+}
+
+variable "zone_id" {
+  description = "Route53 hosted zone ID for DNS validation"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Tags to apply to the certificate"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/cloudfront/main.tf
+++ b/terraform/modules/cloudfront/main.tf
@@ -1,0 +1,63 @@
+resource "aws_cloudfront_distribution" "this" {
+  origin {
+    domain_name = var.origin_domain_name
+    origin_id   = var.origin_id
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  enabled             = var.enabled
+  is_ipv6_enabled     = var.is_ipv6_enabled
+  default_root_object = var.default_root_object
+  aliases             = var.aliases
+
+  default_cache_behavior {
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = var.origin_id
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+  }
+
+  dynamic "custom_error_response" {
+    for_each = var.custom_error_responses
+    content {
+      error_code         = custom_error_response.value.error_code
+      response_code      = custom_error_response.value.response_code
+      response_page_path = custom_error_response.value.response_page_path
+    }
+  }
+
+  price_class = var.price_class
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = var.certificate_arn == ""
+    acm_certificate_arn            = var.certificate_arn != "" ? var.certificate_arn : null
+    ssl_support_method             = var.certificate_arn != "" ? "sni-only" : null
+    minimum_protocol_version       = var.certificate_arn != "" ? "TLSv1.2_2021" : null
+  }
+
+  tags = var.tags
+}

--- a/terraform/modules/cloudfront/outputs.tf
+++ b/terraform/modules/cloudfront/outputs.tf
@@ -1,0 +1,19 @@
+output "distribution_id" {
+  description = "ID of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.this.id
+}
+
+output "distribution_arn" {
+  description = "ARN of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.this.arn
+}
+
+output "distribution_domain_name" {
+  description = "Domain name of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.this.domain_name
+}
+
+output "distribution_hosted_zone_id" {
+  description = "Hosted zone ID of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.this.hosted_zone_id
+}

--- a/terraform/modules/cloudfront/variables.tf
+++ b/terraform/modules/cloudfront/variables.tf
@@ -1,0 +1,61 @@
+variable "origin_domain_name" {
+  description = "Domain name of the origin"
+  type        = string
+}
+
+variable "origin_id" {
+  description = "Unique identifier for the origin"
+  type        = string
+}
+
+variable "aliases" {
+  description = "List of domain aliases for the distribution"
+  type        = list(string)
+  default     = []
+}
+
+variable "certificate_arn" {
+  description = "ARN of the SSL certificate"
+  type        = string
+  default     = ""
+}
+
+variable "default_root_object" {
+  description = "Default root object"
+  type        = string
+  default     = "index.html"
+}
+
+variable "price_class" {
+  description = "Price class for the distribution"
+  type        = string
+  default     = "PriceClass_100"
+}
+
+variable "enabled" {
+  description = "Whether the distribution is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "is_ipv6_enabled" {
+  description = "Whether IPv6 is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "custom_error_responses" {
+  description = "Custom error responses"
+  type = list(object({
+    error_code         = number
+    response_code      = number
+    response_page_path = string
+  }))
+  default = []
+}
+
+variable "tags" {
+  description = "Tags to apply to the distribution"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/route53/main.tf
+++ b/terraform/modules/route53/main.tf
@@ -1,0 +1,28 @@
+resource "aws_route53_zone" "this" {
+  count = var.create_zone ? 1 : 0
+  name  = var.domain_name
+  tags  = var.tags
+}
+
+locals {
+  zone_id = var.create_zone ? aws_route53_zone.this[0].zone_id : var.zone_id
+}
+
+resource "aws_route53_record" "this" {
+  count   = length(var.records)
+  zone_id = local.zone_id
+  name    = var.records[count.index].name
+  type    = var.records[count.index].type
+
+  dynamic "alias" {
+    for_each = var.records[count.index].alias != null ? [var.records[count.index].alias] : []
+    content {
+      name                   = alias.value.name
+      zone_id                = alias.value.zone_id
+      evaluate_target_health = alias.value.evaluate_target_health
+    }
+  }
+
+  ttl     = var.records[count.index].alias == null ? var.records[count.index].ttl : null
+  records = var.records[count.index].alias == null ? var.records[count.index].records : null
+}

--- a/terraform/modules/route53/outputs.tf
+++ b/terraform/modules/route53/outputs.tf
@@ -1,0 +1,15 @@
+output "zone_id" {
+  description = "ID of the Route53 hosted zone"
+  value       = local.zone_id
+}
+
+output "zone_arn" {
+  description = "ARN of the Route53 hosted zone"
+  value       = var.create_zone ? aws_route53_zone.this[0].arn : null
+}
+
+output "name_servers" {
+  description = "Name servers for the hosted zone"
+  value       = var.create_zone ? aws_route53_zone.this[0].name_servers : null
+  sensitive   = true
+}

--- a/terraform/modules/route53/variables.tf
+++ b/terraform/modules/route53/variables.tf
@@ -1,0 +1,38 @@
+variable "domain_name" {
+  description = "Domain name for the hosted zone"
+  type        = string
+}
+
+variable "create_zone" {
+  description = "Whether to create a new hosted zone"
+  type        = bool
+  default     = true
+}
+
+variable "zone_id" {
+  description = "Existing hosted zone ID (if not creating new)"
+  type        = string
+  default     = ""
+}
+
+variable "records" {
+  description = "List of DNS records to create"
+  type = list(object({
+    name    = string
+    type    = string
+    ttl     = optional(number, 300)
+    records = optional(list(string), [])
+    alias = optional(object({
+      name                   = string
+      zone_id                = string
+      evaluate_target_health = bool
+    }), null)
+  }))
+  default = []
+}
+
+variable "tags" {
+  description = "Tags to apply to the hosted zone"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -1,0 +1,41 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+  tags   = var.tags
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = var.enable_versioning ? "Enabled" : "Disabled"
+  }
+}
+
+resource "aws_s3_bucket_website_configuration" "this" {
+  count  = var.enable_website ? 1 : 0
+  bucket = aws_s3_bucket.this.id
+
+  index_document {
+    suffix = var.index_document
+  }
+
+  error_document {
+    key = var.error_document
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = var.block_public_acls
+  block_public_policy     = var.block_public_policy
+  ignore_public_acls      = var.ignore_public_acls
+  restrict_public_buckets = var.restrict_public_buckets
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  count  = var.bucket_policy != "" ? 1 : 0
+  bucket = aws_s3_bucket.this.id
+  policy = var.bucket_policy
+
+  depends_on = [aws_s3_bucket_public_access_block.this]
+}

--- a/terraform/modules/s3/outputs.tf
+++ b/terraform/modules/s3/outputs.tf
@@ -1,0 +1,29 @@
+output "bucket_id" {
+  description = "ID of the S3 bucket"
+  value       = aws_s3_bucket.this.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the S3 bucket"
+  value       = aws_s3_bucket.this.arn
+}
+
+output "bucket_domain_name" {
+  description = "Domain name of the S3 bucket"
+  value       = aws_s3_bucket.this.bucket_domain_name
+}
+
+output "bucket_regional_domain_name" {
+  description = "Regional domain name of the S3 bucket"
+  value       = aws_s3_bucket.this.bucket_regional_domain_name
+}
+
+output "website_endpoint" {
+  description = "Website endpoint of the S3 bucket"
+  value       = var.enable_website ? aws_s3_bucket_website_configuration.this[0].website_endpoint : null
+}
+
+output "website_domain" {
+  description = "Website domain of the S3 bucket"
+  value       = var.enable_website ? aws_s3_bucket_website_configuration.this[0].website_domain : null
+}

--- a/terraform/modules/s3/variables.tf
+++ b/terraform/modules/s3/variables.tf
@@ -1,0 +1,64 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}
+
+variable "enable_versioning" {
+  description = "Enable versioning for the S3 bucket"
+  type        = bool
+  default     = false
+}
+
+variable "enable_website" {
+  description = "Enable static website hosting"
+  type        = bool
+  default     = false
+}
+
+variable "index_document" {
+  description = "Index document for website hosting"
+  type        = string
+  default     = "index.html"
+}
+
+variable "error_document" {
+  description = "Error document for website hosting"
+  type        = string
+  default     = "error.html"
+}
+
+variable "block_public_acls" {
+  description = "Block public ACLs"
+  type        = bool
+  default     = true
+}
+
+variable "block_public_policy" {
+  description = "Block public policy"
+  type        = bool
+  default     = true
+}
+
+variable "ignore_public_acls" {
+  description = "Ignore public ACLs"
+  type        = bool
+  default     = true
+}
+
+variable "restrict_public_buckets" {
+  description = "Restrict public buckets"
+  type        = bool
+  default     = true
+}
+
+variable "bucket_policy" {
+  description = "Bucket policy JSON"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Tags to apply to the bucket"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,3 +4,10 @@ variable "service_name" {
   default     = "SaveMyPodo"
   
 }
+
+variable "environment" {
+  description = "Deployment environment (e.g., dev, staging, prod)"
+  type        = string
+  default     = "dev"
+  
+}


### PR DESCRIPTION
## ✅ 요약
- acm,cloudfront,s3,route53 설정 완료

## 🧩 변경 내용
- acm,cloudfront,s3,route53 모듈추가
- s3 웹호스팅, https 연결, 도메인 세팅완료 

## 🔍 확인 필요사항 (선택)
s3에 리액트 빌드파일 업로드후 테스트 필요 -> 캐시전략 수정가능

## 📝 메모 
