### PR TITLE
[fix] eks 부트스트랩 노드에 launch_template추가

### DIFF
--- a/deploy-eks.ps1
+++ b/deploy-eks.ps1
@@ -137,8 +137,8 @@ Write-Host "`n10. Karpenter 설치 중..." -ForegroundColor Cyan
 helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version v0.32.1 `
     --namespace karpenter --create-namespace `
     --set settings.aws.clusterName=$ClusterName `
-    --set settings.aws.defaultInstanceProfile="$ClusterName-KarpenterNodeInstanceProfile" `
     --set settings.aws.interruptionQueueName="$ClusterName" `
+    --set settings.aws.defaultInstanceProfile="$ClusterName-karpenter-instance-profile" `
     --wait
 
 # Karpenter Pod가 Ready 상태가 될 때까지 대기

--- a/manifests/init/karpenter.yaml
+++ b/manifests/init/karpenter.yaml
@@ -50,7 +50,7 @@ metadata:
   name: default
 spec:
   amiFamily: AL2
-  role: arn:aws:iam::061039804626:role/savemypodo-cluster-node-role
+  # instanceProfile: savemypodo-cluster-karpenter-instance-profile
   subnetSelectorTerms:
     - tags:
         karpenter.sh/discovery: savemypodo-cluster

--- a/terraform/modules/eks/irsa-roles.tf
+++ b/terraform/modules/eks/irsa-roles.tf
@@ -51,6 +51,7 @@ resource "aws_iam_policy" "karpenter" {
           "ec2:DescribeInstanceTypeOfferings",
           "ec2:DescribeAvailabilityZones",
           "ec2:DeleteLaunchTemplate",
+          "ec2:GetInstanceTypesFromInstanceRequirements",
           "ec2:CreateTags",
           "ec2:CreateLaunchTemplate",
           "ec2:CreateFleet",

--- a/terraform/modules/eks/variables.tf
+++ b/terraform/modules/eks/variables.tf
@@ -24,7 +24,12 @@ variable "private_subnet_ids" {
   type        = list(string)
 }
 
-
+variable "eks_version" {
+  description = "EKS version to use for the cluster"
+  type        = string
+  default     = "1.31"
+  
+}
 
 variable "tags" {
   description = "Tags to apply to resources"


### PR DESCRIPTION
## ✅ 요약
IMDS에러로 카펜터가 실행되지 않아 런치템플릿에서 IMDS 버전을 1,2 호환가능하게 했습니다. 
