### PR TITLE
[hotfix] oidc 모듈 경로 수정

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -557,7 +557,7 @@ resource "aws_sqs_queue" "karpenter_interruption_queue" {
 
 
 module "github_oidc_role" {
-  source = "../modules/github_oidc_role"
+  source = "./modules/github_oidc_role"
 
   role_name           = "${var.service_name}-GitHubActionsOIDCRole-Frontend"
   github_repo_pattern = "repo:CLD-3rd/team2-frontend:*"
@@ -592,8 +592,4 @@ module "github_oidc_role" {
       })
     }
   ]
-}
-
-output "oidc_role_arn" {
-  value = module.github_oidc_role.role_arn
 }


### PR DESCRIPTION
## ✅ 요약
루트 디렉토리의 main.tf 에서 github_oidc_role 모듈 경로를 ../ 에서 ./ 로 수정
