### PR TITLE
[fix]53포트 노드그룹 보안그룹 수정

### DIFF
--- a/manifests/base/monitoring/app-service-monitor.yaml
+++ b/manifests/base/monitoring/app-service-monitor.yaml
@@ -13,7 +13,7 @@ spec:
     matchNames:
       - default
   endpoints:
-  - port: http
+  - port: "http"
     path: /actuator/prometheus
     interval: 15s
     scrapeTimeout: 10s

--- a/terraform/modules/eks/main.tf
+++ b/terraform/modules/eks/main.tf
@@ -120,12 +120,27 @@ resource "aws_security_group" "node_sg" {
     security_groups = [aws_security_group.cluster_sg.id]
   }
 
+  ingress {
+    from_port   = 53
+    to_port     = 53
+    protocol    = "udp"
+    self        = true
+  }
+
+  ingress {
+    from_port   = 53
+    to_port     = 53
+    protocol    = "tcp"
+    self        = true
+  }
+
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  
 
   tags = merge(var.tags, {
     Name = "${var.cluster_name}-node-sg"


### PR DESCRIPTION
## ✅ 요약
karpenter CoreDNS 연결 오류를 해결하기 위해  노드그룹 보안그룹에서 53번 포트를 열어주었습니다.